### PR TITLE
Set up WakaTime API Key + zsh

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -13,5 +13,6 @@ vscode:
 
 
 tasks:
-  - init: npm install
-
+  - before: printf "\n[settings]\napi_key = $WAKATIME_API_KEY\n" > ~/.wakatime.cfg
+    init: npm install
+    command: zsh


### PR DESCRIPTION
Hi @carl-parrish!

Here is a fix for:
- installing the WakaTime API key
- auto-starting `zsh`